### PR TITLE
initial implementation of the k8s proxy

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,9 @@
+export DRONE_REPO_NAME=dronerepo
+export DRONE_WORKSPACE=/Users/haha
+export DRONE_BUILD_NUMBER=123
+export PLUGIN_ORIGINAL_IMAGE=bash
+#export PLUGIN_ORIGINAL_COMMANDS="while : ; do echo hello tourist; sleep 1; done"
+export PLUGIN_ORIGINAL_COMMANDS="echo 'hello tourist'"
+export PLUGIN_SERVICE_ACCOUNT=default
+export PLUGIN_JOB_WORKSPACE=tmp
+export PLUGIN_JOB_LABEL_SELECTOR=etwas

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+.idea/*
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.9.2-alpine3.7
+
+RUN apk add --no-cache git mercurial
+ADD . /go/src/github.com/banzaicloud/drone-plugin-k8s-client
+WORKDIR /go/src/github.com/banzaicloud/drone-plugin-k8s-client
+RUN go-wrapper download
+RUN go build -o /bin/k8s-proxy .
+
+FROM alpine:3.7
+
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+COPY --from=0 /bin/k8s-proxy /bin
+ENTRYPOINT ["/bin/k8s-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+EXECUTABLE ?= k8s-proxy
+IMAGE ?= banzaicloud/plugin-$(EXECUTABLE)
+TAG ?= dev-$(shell git log -1 --pretty=format:"%h")
+
+PACKAGES = $(shell go list ./... | grep -v /vendor/)
+
+.DEFAULT_GOAL := list
+
+.PHONY: list
+list:
+	@$(MAKE) -pRrn : -f $(MAKEFILE_LIST) 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
+
+all: clean deps fmt vet docker push
+
+clean:
+	rm -rf bin/*
+	go clean -i ./...
+
+deps:
+	go get ./...
+
+fmt:
+	go fmt $(PACKAGES)
+
+vet:
+	go vet $(PACKAGES)
+
+docker:
+	docker build --rm -t $(IMAGE):$(TAG) .
+
+push:
+	docker push $(IMAGE):$(TAG)
+
+run-dev:
+	. .env
+	go run $(wildcard *.go)

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,2 @@
+package: github.com/banzaicloud/drone-plugin-k8s-client
+import: []

--- a/main.go
+++ b/main.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"flag"
+
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"path/filepath"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	label      = "label-name"
+	appName    = "k8s client plugin"
+	appVersion = "0.0.1"
+)
+
+var (
+	labels = map[string]string{label: "labelValue"}
+)
+
+func main() {
+
+	app := cli.NewApp()
+	app.Name = appName
+	app.Usage = ""
+	app.Action = run
+	app.Version = fmt.Sprintf("%s", appVersion)
+	app.EnableBashCompletion = true
+
+	app.Flags = []cli.Flag{
+
+		cli.StringFlag{
+			Name:   "plugin.job.namespace",
+			Usage:  "the namespace of the job",
+			EnvVar: "PLUGIN_JOB_NAMESPACE",
+			Value:  "default",
+		},
+		cli.StringFlag{
+			Name:   "plugin.original.image",
+			Usage:  "the image to ebe run on the cluster",
+			EnvVar: "PLUGIN_ORIGINAL_IMAGE",
+		},
+		cli.StringFlag{
+			Name:   "plugin.proxy.service.account",
+			Usage:  "the service account name",
+			EnvVar: "PLUGIN_PROXY_SERVICE_ACCOUNT",
+			Value:  "default",
+		},
+		cli.StringFlag{
+			Name:   "plugin.job.workspace",
+			Usage:  "repository full name",
+			EnvVar: "PLUGIN_JOB_WORKSPACE",
+		},
+
+		cli.StringFlag{
+			Name:   "plugin.job.label.selector",
+			Usage:  "repository full name",
+			EnvVar: "PLUGIN_JOB_LABEL_SELECTOR",
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		logrus.Errorf("plugin execution failed. error: %s", err)
+		os.Exit(1)
+	}
+
+}
+
+func run(c *cli.Context) error {
+
+	logrus.Debugf("plugin environment: %s", os.Environ())
+	flag.Parse()
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath())
+	if err != nil {
+		logrus.Errorf("could not build kubeconfig. err: %s", err)
+		return err
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+
+	if err != nil {
+		logrus.Errorf("could not get client set  %s", err)
+		return err
+	}
+
+	if err != nil {
+		logrus.Errorf("could not read env  %s", err)
+		return err
+	}
+	var wg sync.WaitGroup
+
+	plugin := Plugin{
+		Namespace:        c.String("plugin.job.namespace"),
+		Image:            c.String("plugin.original.image"),
+		ServiceAccount:   c.String("plugin.proxy.service.account"),
+		Workspace:        workspace(),
+		WorkspacePVC:     workspacePVC(),
+		JobName:          jobName(),
+		OriginalCommands: originalCommands(),
+		LabelSelector:    labels,
+		Env:              pluginEnv(),
+		Wg:               &wg,
+	}
+
+	_, err = plugin.CreateOrGetPVC(clientSet)
+	if err != nil {
+		logrus.Errorf("could not create PVC. err [ %s ]", err)
+		return err
+	}
+
+	jobWatcher, err := plugin.WatchJob(clientSet)
+	if err != nil {
+		logrus.Errorf("could not watch jobs. err [ %s ]", err)
+		return err
+	}
+
+	err = plugin.CreateJob(clientSet)
+	if err != nil {
+		jobWatcher.Stop()
+		return err
+	}
+
+	err = plugin.JobEvents(jobWatcher, clientSet)
+	if err != nil {
+		logrus.Errorf("error encountered: %s", err)
+		return err
+	}
+
+	plugin.Wg.Wait()
+	plugin.Cleanup(clientSet)
+
+	return nil
+
+}
+
+// WorkspacePVC assembles the name of the persistent volume claim based on the available environment
+func workspacePVC() string {
+	//DRONE_WORKSPACE_PVC=$DRONE_REPO_NAME"-"$DRONE_BUILD_NUMBER"-WORKSPACE"
+	// PVC must be lowercase!
+	workSpacePVC := strings.ToLower(strings.Join([]string{os.Getenv("DRONE_REPO_NAME"),
+		os.Getenv("DRONE_BUILD_NUMBER"), "WORKSPACE"}, "-"))
+
+	logrus.Debugf("workspace PVC name: [ %s ]", workSpacePVC)
+	return workSpacePVC
+}
+
+func workspace() string {
+	ws := os.Getenv("DRONE_WORKSPACE")
+	logrus.Debugf("workspace: [ %s ]", ws)
+	return ws
+}
+
+// JobName assembles the name of the job based on the available environment
+func jobName() string {
+	//DRONE_JOB_NAME=$DRONE_REPO_NAME"-"$DRONE_BUILD_NUMBER-`date +%s`
+	jobName := strings.Join([]string{os.Getenv("DRONE_REPO_NAME"), os.Getenv("DRONE_BUILD_NUMBER"),
+		strconv.FormatInt(time.Now().Unix(), 10)}, "-")
+	logrus.Debugf("job name: [ %s ]", jobName)
+	return jobName
+}
+
+// OriginalCommands parses the passed in original command
+// The original command is passed to the containar "as is"
+func originalCommands() []string {
+	oc, ok := os.LookupEnv("PLUGIN_ORIGINAL_COMMANDS")
+	if ok == false || oc == "" {
+		return nil
+	}
+	logrus.Debugf("original commands: [ %s ]", oc)
+	return []string{oc}
+}
+
+// KubeConfigPath assembles the path to the Kubernetes config file
+func kubeConfigPath() string {
+	//export KUBECONFIG="$DRONE_WORKSPACE/.kube/config"
+	kubeConfigPath := filepath.Join(os.Getenv("DRONE_WORKSPACE"), ".kube", "config")
+	logrus.Infof("kube config path: [ %s ]", kubeConfigPath)
+	return kubeConfigPath
+}
+
+func pluginEnv() map[string]string {
+	pluginEnv := map[string]string{}
+	for _, envVar := range os.Environ() {
+		keyVal := strings.SplitN(envVar, "=", 2)
+		pluginEnv[keyVal[0]] = keyVal[1]
+	}
+	logrus.Debugf("parsed env map: %s", pluginEnv)
+	return pluginEnv
+}

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,427 @@
+package main
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"strings"
+
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/batch/v1"
+	coreV1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Plugin struct represents the data available for the plugin's logic.
+type Plugin struct {
+	JobName          string
+	Namespace        string
+	Image            string
+	Workspace        string
+	WorkspacePVC     string
+	ServiceAccount   string
+	OriginalCommands []string
+	LabelSelector    map[string]string
+	Env              map[string]string
+	Wg               *sync.WaitGroup
+}
+
+const (
+	JobWatcherStatusKey = "job"
+	PodWatcherStatusKey = "pod"
+	LogWatcherStatusKey = "log"
+
+	pluginEnvPrefix = "PLUGIN_"
+	droneEnvPrefix  = "DRONE_"
+)
+
+var (
+	// the period before a resource (job, pvc) gets deleted
+	gracePeriodSeconds = int64(2)
+)
+
+func init() {
+	logrus.SetOutput(os.Stdout)
+	logrus.SetLevel(logrus.InfoLevel)
+}
+
+func watchingStatusOn(watcherStatusKey string) {
+	logrus.Debugf("Switching on logging status for: [ %s ]", watcherStatusKey)
+	watcherStatusMap[watcherStatusKey] = true
+}
+
+func watchingStatusOff(watcherStatusKey string) {
+	logrus.Debugf("Switching off logging status for: [ %s ]", watcherStatusKey)
+	watcherStatusMap[watcherStatusKey] = false
+}
+
+func watchingStatus(watcherStatusKey string) bool {
+	return watcherStatusMap[watcherStatusKey]
+}
+
+var (
+	// internal status of the watchers
+	watcherStatusMap = map[string]bool{"job": false, "pod": false, "log": false}
+)
+
+func (p *Plugin) handleJobEvent(event watch.Event, watcher watch.Interface, clientSet *kubernetes.Clientset) error {
+
+	payloadType := reflect.TypeOf(event.Object)
+	payload := reflect.ValueOf(event.Object).Interface().(*v1.Job)
+	logrus.Debugf("received JOB event with payload type [ %s ]", payloadType)
+
+	switch event.Type {
+	case watch.Added:
+		logrus.Debugf("job added; name: [ %s ], status: [ %s ], ", payload.GetName(), payload.Status.String())
+	case watch.Modified:
+		logrus.Debugf("job modified, status: %s", payload.Status.String())
+
+		if payload.Status.Failed > 0 {
+			watcher.Stop()
+			return errors.New(fmt.Sprintf("there are [ %d ] failed pods", payload.Status.Failed))
+		}
+
+		if payload.Status.Succeeded > 0 {
+			// watcher stopped + nil == app is quitting
+			watcher.Stop()
+			return nil
+		}
+
+		if watchingStatus(PodWatcherStatusKey) == true {
+			logrus.Debugf("pod is already being watched")
+			return nil
+		}
+
+		podWatcher, err := p.WatchPod(clientSet)
+		if err != nil {
+			logrus.Errorf("could not watch pod")
+			return err
+		}
+
+		p.Wg.Add(1)
+		// new goroutine as it blocks
+		go p.PodEvents(podWatcher, clientSet)
+
+	case watch.Deleted:
+		logrus.Debugf("job deleted; name: [ %s ]", payload.GetName())
+		logrus.Debugf("closing the job watcher")
+		watcher.Stop()
+	case watch.Error:
+		logrus.Debugf("job in error, status: [ %s ]", event.Object.GetObjectKind())
+	default:
+		logrus.Warnf("received (unhandled) event of type: [ %s ]", payloadType)
+	}
+
+	return nil
+
+}
+
+func (p *Plugin) handlePodEvent(event watch.Event, watcher watch.Interface, clientSet *kubernetes.Clientset) {
+
+	payload := reflect.ValueOf(event.Object).Interface().(*coreV1.Pod)
+
+	switch event.Type {
+	case watch.Added:
+		logrus.Debugf("pod [ %s ] added, phase: [ %s ]", payload.GetName(), payload.Status.Phase)
+
+	case watch.Modified:
+		logrus.Debugf("pod [ %s ] modified, phase: [ %s ]", payload.GetName(), payload.Status.Phase)
+
+		if watchingStatus(LogWatcherStatusKey) == true {
+			logrus.Debugf("logs already being watched")
+			return
+		}
+
+		// new thread not to block here
+		go p.WatchLogs(payload.GetName(), clientSet)
+	case watch.Error:
+		logrus.Debugf("pod in error, phase: [ %s ]", payload.Status.Phase)
+	case watch.Deleted:
+		logrus.Debugf("pod [ %s] deleted", payload.GetName())
+		logrus.Debugf("closing the pod watcher")
+		watcher.Stop()
+		watchingStatusOff(PodWatcherStatusKey)
+	default:
+		logrus.Warn("received (unhandled) event of type: [ %s ]", event.Type)
+	}
+
+}
+
+// CreateJob creates and launches a Job resource on the k8s cluster
+func (p *Plugin) CreateJob(clientSet *kubernetes.Clientset) error {
+	jobToRun, err := p.assembleJob()
+	if err != nil {
+		logrus.Errorf("could not set up job. error: %s", err)
+		return err
+	}
+
+	jobToRun, err = p.DecorateJob(jobToRun)
+	if err != nil {
+		logrus.Errorf("could not decorate job. error: %s", err)
+		return err
+	}
+
+	job, err := clientSet.BatchV1().Jobs(p.Namespace).Create(jobToRun)
+	if err != nil {
+		logrus.Errorf("could not create job. error: %s", err)
+		return err
+	}
+
+	logrus.Infof("created job: [ %s ]", job.GetName())
+	return nil
+}
+
+// DeleteJob deletes a job from the k8s cluster
+func (p *Plugin) DeleteJob(clientSet *kubernetes.Clientset) error {
+
+	deleteOptions := metaV1.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds}
+
+	err := clientSet.BatchV1().Jobs(p.Namespace).Delete(p.JobName, &deleteOptions)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("deleted job: [ %s ]", p.JobName)
+	return nil
+
+}
+
+// assembleJob builds the Job struct based on the plugin
+func (p *Plugin) assembleJob() (*v1.Job, error) {
+
+	falseVal := false
+
+	batchJob := &v1.Job{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       "Job",
+			APIVersion: "batch/v1",
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:   p.JobName,
+			Labels: p.LabelSelector,
+		},
+		Spec: v1.JobSpec{
+			Template: coreV1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:   p.JobName,
+					Labels: p.LabelSelector,
+				},
+				Spec: coreV1.PodSpec{
+					ServiceAccountName: p.ServiceAccount,
+					Containers: []coreV1.Container{
+						{
+							Name:       p.JobName,
+							Image:      p.Image,
+							WorkingDir: p.Workspace,
+							SecurityContext: &coreV1.SecurityContext{
+								Privileged: &falseVal,
+							},
+							ImagePullPolicy: coreV1.PullPolicy(coreV1.PullIfNotPresent),
+							Env:             p.originalEnvVars(),
+							VolumeMounts: []coreV1.VolumeMount{
+								coreV1.VolumeMount{
+									Name:      p.JobName,
+									MountPath: p.Workspace,
+								},
+							},
+						},
+					},
+					RestartPolicy: coreV1.RestartPolicyNever,
+					Volumes: []coreV1.Volume{
+						coreV1.Volume{
+							Name: p.JobName,
+							VolumeSource: coreV1.VolumeSource{
+								PersistentVolumeClaim: &coreV1.PersistentVolumeClaimVolumeSource{
+									ClaimName: p.WorkspacePVC,
+								},
+							},
+						},
+					},
+					ImagePullSecrets: []coreV1.LocalObjectReference{},
+				},
+			},
+		},
+	}
+
+	return batchJob, nil
+
+}
+
+func (p *Plugin) DecorateJob(job *v1.Job) (*v1.Job, error) {
+
+	if p.OriginalCommands != nil && len(p.OriginalCommands) > 0 {
+		// we assume there is a single container only in the job/pod specification
+		container := &job.Spec.Template.Spec.Containers[0]
+		container.Command = []string{"sh", "-c"}
+		container.Args = p.OriginalCommands
+		logrus.Debugf("set original command: [ %s ] with argument(s): [ %s ]", container.Command, container.Args)
+	}
+	return job, nil
+}
+
+func (p *Plugin) WatchLogs(podName string, clientSet *kubernetes.Clientset) {
+
+	logOptions := coreV1.PodLogOptions{
+		Follow: true,
+	}
+	req := clientSet.CoreV1().Pods(p.Namespace).GetLogs(podName, &logOptions)
+
+	readCloser, err := req.Stream()
+	if err != nil {
+		logrus.Debugf("could not stream the logs. error: %s", err)
+		watchingStatusOff(LogWatcherStatusKey)
+		return
+	}
+
+	//close the readcloser on exiting this method
+	defer readCloser.Close()
+
+	logrus.Infof("***** streaming the logs for pod [ %s ] *****", podName)
+	watchingStatusOn(LogWatcherStatusKey)
+
+	// this is blocking till logs are written
+	written, err := io.Copy(os.Stdout, readCloser)
+
+	logrus.Debugf("Bytes written: [ %s ]. error: [ %s ]. ", written, err)
+	watchingStatusOff(LogWatcherStatusKey)
+	// regardless the result of copy the goroutine ends here, need to signal it
+	p.Wg.Done()
+
+}
+
+func (p *Plugin) WatchJob(clientSet *kubernetes.Clientset) (watch.Interface, error) {
+
+	// set up the proper list options, use labels
+	options := metaV1.ListOptions{
+		Watch:         true,
+		LabelSelector: strings.Join([]string{label, labels[label]}, "="),
+	}
+
+	jobWatcher, err := clientSet.BatchV1().Jobs(p.Namespace).Watch(options)
+	if err != nil {
+		logrus.Errorf("could not watch jobs. err: %s", err)
+		watchingStatusOff(JobWatcherStatusKey)
+		return nil, err
+	}
+	watchingStatusOn(JobWatcherStatusKey)
+	logrus.Infof("job watcher started")
+	return jobWatcher, nil
+
+}
+
+func (p *Plugin) WatchPod(clientSet *kubernetes.Clientset) (watch.Interface, error) {
+
+	// set up the proper list options, use labels
+	options := metaV1.ListOptions{
+		LabelSelector: strings.Join([]string{label, p.LabelSelector[label]}, "="),
+	}
+
+	// at his point we don't know the name of the pod
+	podWatcher, err := clientSet.CoreV1().Pods(p.Namespace).Watch(options)
+	if err != nil {
+		logrus.Errorf("could not watch pod. err: %s", err)
+		watchingStatusOff(PodWatcherStatusKey)
+		return nil, err
+	}
+
+	watchingStatusOn(PodWatcherStatusKey)
+	logrus.Debugf("pod watcher started")
+	return podWatcher, nil
+
+}
+
+// JobEvents handles job related events. Blocks till watcher is closed
+func (p *Plugin) JobEvents(watcher watch.Interface, clientSet *kubernetes.Clientset) error {
+	for event := range watcher.ResultChan() {
+		err := p.handleJobEvent(event, watcher, clientSet)
+		if err != nil {
+			return err
+		}
+	}
+	logrus.Infof("job succeeded")
+	// wait till the log reader goroutine is done
+	return nil
+}
+
+// PodEvents handles pod related events. Blocks till watcher is closed
+func (p *Plugin) PodEvents(watcher watch.Interface, clientSet *kubernetes.Clientset) {
+	for event := range watcher.ResultChan() {
+		p.handlePodEvent(event, watcher, clientSet)
+	}
+}
+
+// OriginalEnvVars processes the environment passed to the job (selects specially prefixed env vars)
+func (p *Plugin) originalEnvVars() []coreV1.EnvVar {
+	originalEnv := make([]coreV1.EnvVar, 0)
+	for key, val := range p.Env {
+		if strings.HasPrefix(key, pluginEnvPrefix) || strings.HasPrefix(key, droneEnvPrefix) {
+			originalEnv = append(originalEnv, coreV1.EnvVar{
+				Name:  key,
+				Value: val,
+			})
+		}
+	}
+	logrus.Debugf("original env passed to the job: %#v", originalEnv)
+	return originalEnv
+}
+
+// CreateOrGetPVC creates a persistent volume claim resource in case it doesn't already exist
+func (p *Plugin) CreateOrGetPVC(clientSet *kubernetes.Clientset) (*coreV1.PersistentVolumeClaim, error) {
+
+	claim, err := clientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Get(p.WorkspacePVC, metaV1.GetOptions{})
+	if err != nil {
+		logrus.Warnf("error while getting the PVC: [%s], error %s;", p.WorkspacePVC, err)
+	} else {
+		logrus.Debugf("using existing PVC: [ %s ]", claim.String())
+		return claim, nil
+	}
+
+	pvc := coreV1.PersistentVolumeClaim{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:   p.WorkspacePVC,
+			Labels: p.LabelSelector,
+		},
+		Spec: coreV1.PersistentVolumeClaimSpec{
+			AccessModes: []coreV1.PersistentVolumeAccessMode{coreV1.ReadWriteOnce},
+			Resources: coreV1.ResourceRequirements{
+				Requests: map[coreV1.ResourceName]resource.Quantity{
+					coreV1.ResourceStorage: resource.MustParse("3Gi"),
+				},
+			},
+		},
+	}
+
+	claim, err = clientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Create(&pvc)
+	if err != nil {
+		logrus.Errorf("could not create PVC, error %s", err)
+		return nil, err
+	}
+	logrus.Debugf("created PVC: [ %s ]", claim.GetName())
+	return claim, nil
+}
+
+// DeletePVC deletes a persistent volume claim resource
+func (p *Plugin) DeletePVC(clientSet *kubernetes.Clientset) error {
+	deleteOptions := metaV1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+	}
+
+	err := clientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Delete(p.WorkspacePVC, &deleteOptions)
+	if err != nil {
+		logrus.Errorf("could not delete pvc:[ %s ], error: %s", p.WorkspacePVC, err)
+		return err
+	}
+	logrus.Debugf("deleted PVC: [ %s ]", p.WorkspacePVC)
+	return nil
+}
+
+func (p *Plugin) Cleanup(clientSet *kubernetes.Clientset) {
+	p.DeleteJob(clientSet)
+	//p.DeletePVC(clientSet)
+}


### PR DESCRIPTION
The initial version of the k8s proxy functionality.
It sets up a kubernetes Job resource to execute the "original image" on the k8s cluster while watching for the logs of the pod running on the cluster.

To coordinate the goroutines (wait for the log watcher goroutine before the plugin exits) the watchgroup feature is used. (This might be needed to be replaced by a more robust / clean solution - eg plain channels)