### PR TITLE
generated unique label selector for watchers (build number is added …

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,10 +24,6 @@ const (
 	appVersion = "0.0.1"
 )
 
-var (
-	labels = map[string]string{label: "labelValue"}
-)
-
 func main() {
 
 	app := cli.NewApp()
@@ -108,7 +104,7 @@ func run(c *cli.Context) error {
 		WorkspacePVC:     workspacePVC(),
 		JobName:          jobName(),
 		OriginalCommands: originalCommands(),
-		LabelSelector:    labels,
+		LabelSelector:    labelSelector(),
 		Env:              pluginEnv(),
 		Wg:               &wg,
 	}
@@ -197,4 +193,10 @@ func pluginEnv() map[string]string {
 	}
 	logrus.Debugf("parsed env map: %s", pluginEnv)
 	return pluginEnv
+}
+
+func labelSelector() map[string]string {
+	return map[string]string{
+		label: strings.Join([]string{os.Getenv("DRONE_BUILD_NUMBER"), "label"}, "-"),
+	}
 }

--- a/plugin.go
+++ b/plugin.go
@@ -300,7 +300,7 @@ func (p *Plugin) WatchJob(clientSet *kubernetes.Clientset) (watch.Interface, err
 	// set up the proper list options, use labels
 	options := metaV1.ListOptions{
 		Watch:         true,
-		LabelSelector: strings.Join([]string{label, labels[label]}, "="),
+		LabelSelector: strings.Join([]string{label, p.LabelSelector[label]}, "="),
 	}
 
 	jobWatcher, err := clientSet.BatchV1().Jobs(p.Namespace).Watch(options)
@@ -376,7 +376,7 @@ func (p *Plugin) CreateOrGetPVC(clientSet *kubernetes.Clientset) (*coreV1.Persis
 
 	claim, err := clientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Get(p.WorkspacePVC, metaV1.GetOptions{})
 	if err != nil {
-		logrus.Warnf("error while getting the PVC: [%s], error %s;", p.WorkspacePVC, err)
+		logrus.Warnf("error while getting the PVC: [ %s ], error %s;", p.WorkspacePVC, err)
 	} else {
 		logrus.Debugf("using existing PVC: [ %s ]", claim.String())
 		return claim, nil


### PR DESCRIPTION
…as label to the resources)
- label assembled on start using the build number