### PR TITLE
Added support for setting the log level

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,11 +57,15 @@ func main() {
 			Usage:  "repository full name",
 			EnvVar: "PLUGIN_JOB_WORKSPACE",
 		},
-
 		cli.StringFlag{
 			Name:   "plugin.job.label.selector",
 			Usage:  "repository full name",
 			EnvVar: "PLUGIN_JOB_LABEL_SELECTOR",
+		},
+		cli.StringFlag{
+			Name:   "plugin.log.level",
+			Usage:  "the log level for the plugin",
+			EnvVar: "PLUGIN_LOG_LEVEL",
 		},
 	}
 
@@ -74,6 +78,7 @@ func main() {
 }
 
 func run(c *cli.Context) error {
+	processLogLevel(c)
 
 	logrus.Debugf("plugin environment: %s", os.Environ())
 	flag.Parse()
@@ -181,7 +186,7 @@ func originalCommands() []string {
 func kubeConfigPath() string {
 	//export KUBECONFIG="$DRONE_WORKSPACE/.kube/config"
 	kubeConfigPath := filepath.Join(os.Getenv("DRONE_WORKSPACE"), ".kube", "config")
-	logrus.Infof("kube config path: [ %s ]", kubeConfigPath)
+	logrus.Debugf("kube config path: [ %s ]", kubeConfigPath)
 	return kubeConfigPath
 }
 
@@ -198,5 +203,22 @@ func pluginEnv() map[string]string {
 func labelSelector() map[string]string {
 	return map[string]string{
 		label: strings.Join([]string{os.Getenv("DRONE_BUILD_NUMBER"), "label"}, "-"),
+	}
+}
+
+func processLogLevel(c *cli.Context) {
+	switch strings.ToUpper(c.String("plugin.log.level")) {
+	case "INFO":
+		logrus.SetLevel(logrus.InfoLevel)
+	case "DEBUG":
+		logrus.SetLevel(logrus.DebugLevel)
+	case "WARN":
+		logrus.SetLevel(logrus.WarnLevel)
+	case "ERROR":
+		logrus.SetLevel(logrus.ErrorLevel)
+	case "PANIC":
+		logrus.SetLevel(logrus.PanicLevel)
+	default:
+		logrus.SetLevel(logrus.InfoLevel)
 	}
 }

--- a/plugin.go
+++ b/plugin.go
@@ -116,7 +116,7 @@ func (p *Plugin) handleJobEvent(event watch.Event, watcher watch.Interface, clie
 	case watch.Error:
 		logrus.Debugf("job in error, status: [ %s ]", event.Object.GetObjectKind())
 	default:
-		logrus.Warnf("received (unhandled) event of type: [ %s ]", payloadType)
+		logrus.Debugf("received (unhandled) event of type: [ %s ]", payloadType)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (p *Plugin) handlePodEvent(event watch.Event, watcher watch.Interface, clie
 		watcher.Stop()
 		watchingStatusOff(PodWatcherStatusKey)
 	default:
-		logrus.Warn("received (unhandled) event of type: [ %s ]", event.Type)
+		logrus.Debugf("received (unhandled) event of type: [ %s ]", event.Type)
 	}
 
 }
@@ -174,7 +174,7 @@ func (p *Plugin) CreateJob(clientSet *kubernetes.Clientset) error {
 		return err
 	}
 
-	logrus.Infof("created job: [ %s ]", job.GetName())
+	logrus.Debugf("created job: [ %s ]", job.GetName())
 	return nil
 }
 
@@ -187,7 +187,7 @@ func (p *Plugin) DeleteJob(clientSet *kubernetes.Clientset) error {
 	if err != nil {
 		return err
 	}
-	logrus.Infof("deleted job: [ %s ]", p.JobName)
+	logrus.Debugf("deleted job: [ %s ]", p.JobName)
 	return nil
 
 }
@@ -290,6 +290,7 @@ func (p *Plugin) WatchLogs(podName string, clientSet *kubernetes.Clientset) {
 
 	logrus.Debugf("Bytes written: [ %s ]. error: [ %s ]. ", written, err)
 	watchingStatusOff(LogWatcherStatusKey)
+	logrus.Infof("***** end of the logs for pod [ %s ] *****", podName)
 	// regardless the result of copy the goroutine ends here, need to signal it
 	p.Wg.Done()
 
@@ -310,7 +311,7 @@ func (p *Plugin) WatchJob(clientSet *kubernetes.Clientset) (watch.Interface, err
 		return nil, err
 	}
 	watchingStatusOn(JobWatcherStatusKey)
-	logrus.Infof("job watcher started")
+	logrus.Debugf("job watcher started")
 	return jobWatcher, nil
 
 }
@@ -344,7 +345,7 @@ func (p *Plugin) JobEvents(watcher watch.Interface, clientSet *kubernetes.Client
 			return err
 		}
 	}
-	logrus.Infof("job succeeded")
+	logrus.Debugf("job [%s] succeeded", p.JobName)
 	// wait till the log reader goroutine is done
 	return nil
 }


### PR DESCRIPTION
The "proxy" plugin only logs at debug level while its log level is at info level by default. This is to keep the place clean for the remote (pod) logs.
 